### PR TITLE
DP34: add device_id as primary key and uuid field, commented authenti…

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -140,7 +140,7 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
-AUTH_USER_MODEL = 'users.User'
+# AUTH_USER_MODEL = 'users.User'
 
 SWAGGER_SETTINGS = {
     'SECURITY_DEFINITIONS': {

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -1,21 +1,18 @@
-from django.contrib.auth.models import AbstractUser
 from django.db import models
-from services.constants import MAX_DEVICE_ID_LENGTH, MAX_USER_NAME_LENGTH
+from services.constants import MAX_USER_NAME_LENGTH
 from services.validators import validate_name
 
 
-class User(AbstractUser):
+class User(models.Model):
     """Model for users."""
-    USERNAME_FIELD = "device_id"
     name = models.CharField(
         verbose_name="Имя",
         max_length=MAX_USER_NAME_LENGTH,
         validators=[validate_name],
         blank=False,
     )
-    device_id = models.CharField(
+    device_id = models.UUIDField(
         verbose_name="ID устройства",
-        max_length=MAX_DEVICE_ID_LENGTH,
-        blank=False,
-        unique=True,
+        editable=False,
+        primary_key=True,
     )


### PR DESCRIPTION
Что сделал:
- поменял поле device_id в модели Users - теперь это поле UUIDField и primary_key
- закоментил  AUTH_USER_MODEL = 'users.User' в settings, т.к. аутентификации у нас нет