### PR TITLE
Dp 33

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,6 +1,6 @@
 import logging
-import requests.exceptions
 
+import requests.exceptions
 from custom_sessions.models import CustomSession
 from movies.models import Collection, Genre, Movie
 from rest_framework import serializers

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,7 +3,7 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
                                    SpectacularSwaggerView)
 from rest_framework.routers import DefaultRouter
 
-from .views import (CollectionListView,  # MovieDetailView, MovieListView
+from .views import (CollectionListView,
                     CreateUpdateUserView, CustomSessionViewSet, GenreListView,
                     MovieViewSet)
 
@@ -23,11 +23,6 @@ urlpatterns = [
     path(
         'collections/', CollectionListView.as_view(), name='collections_list'
     ),
-    # path('movies/', MovieListView.as_view(), name='movie_list'),
-    # path(
-    #     'movies/<int:movie_id>/',
-    #     MovieDetailView.as_view(), name='movie_detail'
-    # ),
     path('schema/', SpectacularAPIView.as_view(), name='schema'),
     path('schema/docs/', SpectacularSwaggerView.as_view(url_name='schema')),
     path(

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -20,9 +20,12 @@ urlpatterns = [
     path(
         'collections/', CollectionListView.as_view(), name='collections_list'
     ),
-    path('movies/', MovieListView.as_view(), name='movie_list'),
     path(
-        'movies/<int:movie_id>/',
+        'sessions/<str:session_id>/movies/',
+        MovieListView.as_view(), name='movie_list'
+    ),
+    path(
+        'sessions/<str:session_id>/movies/<int:movie_id>/',
         MovieDetailView.as_view(), name='movie_detail'
     ),
     path('schema/', SpectacularAPIView.as_view(), name='schema'),

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,12 +1,11 @@
 from django.urls import include, path
-from drf_spectacular.views import (SpectacularAPIView, SpectacularSwaggerView,
-                                   SpectacularRedocView)
+from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
+                                   SpectacularSwaggerView)
 from rest_framework.routers import DefaultRouter
 
-from .views import (CollectionListView, CreateUpdateUserView,
-                    CustomSessionViewSet, GenreListView, MovieViewSet,
-                    # MovieDetailView, MovieListView
-                    )
+from .views import (CollectionListView,  # MovieDetailView, MovieListView
+                    CreateUpdateUserView, CustomSessionViewSet, GenreListView,
+                    MovieViewSet)
 
 router = DefaultRouter()
 router.register(r'sessions', CustomSessionViewSet, basename='sessions')

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,14 +1,18 @@
 from django.urls import include, path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import (SpectacularAPIView, SpectacularSwaggerView,
+                                   SpectacularRedocView)
 from rest_framework.routers import DefaultRouter
 
 from .views import (CollectionListView, CreateUpdateUserView,
-                    CustomSessionViewSet, GenreListView, MovieDetailView,
-                    MovieListView)
+                    CustomSessionViewSet, GenreListView, MovieViewSet,
+                    # MovieDetailView, MovieListView
+                    )
 
 router = DefaultRouter()
+router.register(r'sessions', CustomSessionViewSet, basename='sessions')
 router.register(
-    r'sessions', CustomSessionViewSet, basename='sessions'
+    r'sessions/(?P<session_id>[^/.]+)/movies',
+    MovieViewSet, basename='movie'
 )
 
 urlpatterns = [
@@ -20,14 +24,16 @@ urlpatterns = [
     path(
         'collections/', CollectionListView.as_view(), name='collections_list'
     ),
-    path(
-        'sessions/<str:session_id>/movies/',
-        MovieListView.as_view(), name='movie_list'
-    ),
-    path(
-        'sessions/<str:session_id>/movies/<int:movie_id>/',
-        MovieDetailView.as_view(), name='movie_detail'
-    ),
+    # path('movies/', MovieListView.as_view(), name='movie_list'),
+    # path(
+    #     'movies/<int:movie_id>/',
+    #     MovieDetailView.as_view(), name='movie_detail'
+    # ),
     path('schema/', SpectacularAPIView.as_view(), name='schema'),
     path('schema/docs/', SpectacularSwaggerView.as_view(url_name='schema')),
+    path(
+        'schema/redoc/',
+        SpectacularRedocView.as_view(url_name='schema'), name='redoc'
+    ),
+
 ]

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -3,9 +3,8 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
                                    SpectacularSwaggerView)
 from rest_framework.routers import DefaultRouter
 
-from .views import (CollectionListView,
-                    CreateUpdateUserView, CustomSessionViewSet, GenreListView,
-                    MovieViewSet)
+from .views import (CollectionListView, CreateUpdateUserView,
+                    CustomSessionViewSet, GenreListView, MovieViewSet)
 
 router = DefaultRouter()
 router.register(r'sessions', CustomSessionViewSet, basename='sessions')

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -9,7 +9,7 @@ from rest_framework.views import APIView
 from services.kinopoisk.kinopoisk_service import (KinopoiskCollections,
                                                   KinopoiskGenres)
 from services.schemas import (collections_schema, genres_schema,
-                              roulette_schema, match_list_schema,
+                              match_list_schema, roulette_schema,
                               session_schema, user_schema)
 from users.models import User
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -110,14 +110,6 @@ class CustomSessionViewSet(viewsets.ModelViewSet):
     @session_schema['create']
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
-    # def get_serializer(self, *args, **kwargs):
-    #     kwargs['context'] = self.get_serializer_context()
-    #     return super().get_serializer(*args, **kwargs)
-
-    # def get_serializer_context(self):
-    #     context = super().get_serializer_context()
-    #     context['request'] = self.request
-    #     return context
 
     @match_list_schema['get']
     @action(detail=True, methods=['get'])
@@ -152,15 +144,20 @@ class CustomSessionViewSet(viewsets.ModelViewSet):
 class MovieListView(generics.ListAPIView):
     """Представление списка фильмов."""
 
-    queryset = Movie.objects.all()
     serializer_class = MovieSerializer
+
+    def get_queryset(self):
+        session_id = self.kwargs.get('session_id')
+        session = get_object_or_404(CustomSession, id=session_id)
+        return session.movies
 
 
 class MovieDetailView(APIView):
     """Представление для получения деталей конкретного фильма."""
 
     @movie_detail_schema['get']
-    def get(self, request, movie_id):
-        movie = get_object_or_404(Movie, id=movie_id)
+    def get(self, request, session_id, movie_id):
+        session = get_object_or_404(CustomSession, id=session_id)
+        movie = get_object_or_404(Movie, id=movie_id, custom_sessions=session)
         serializer = MovieDetailSerializer(movie)
         return Response(serializer.data)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -10,7 +10,7 @@ from rest_framework.views import APIView
 from services.kinopoisk.kinopoisk_service import (KinopoiskCollections,
                                                   KinopoiskGenres)
 from services.schemas import (match_list_schema, movie_detail_schema,
-                              user_schema)
+                              session_schema, user_schema)
 from users.models import User
 
 from .serializers import (CollectionSerializer, CustomSessionCreateSerializer,
@@ -25,18 +25,20 @@ class CreateUpdateUserView(APIView):
 
     @user_schema['get']
     def get(self, request):
-        device_id = request.headers.get('device_id')
+        device_id = request.headers.get('Device-Id')
         if device_id:
             user = get_object_or_404(User, device_id=device_id)
             serializer = CustomUserSerializer(user)
             return Response(serializer.data,
                             status=status.HTTP_200_OK)
-        return Response({'error_message': 'Device id не был передан.'},
+        return Response({'error_message': 'Device-Id не был передан.'},
                         status=status.HTTP_400_BAD_REQUEST)
 
     @user_schema['create']
     def post(self, request):
-        device_id = request.headers.get('device_id')
+        device_id = request.headers.get('Device-Id')
+        print(device_id)
+        print(request.headers)
         if device_id:
             serializer = CustomUserSerializer(
                 data=request.data,
@@ -48,12 +50,12 @@ class CreateUpdateUserView(APIView):
                                 status=status.HTTP_201_CREATED)
             return Response(serializer.errors,
                             status=status.HTTP_400_BAD_REQUEST)
-        return Response({'error_message': 'Device id не был передан.'},
+        return Response({'error_message': 'Device-Id не был передан.'},
                         status=status.HTTP_400_BAD_REQUEST)
 
     @user_schema['update']
     def put(self, request):
-        device_id = request.headers.get('device_id')
+        device_id = request.headers.get('Device-Id')
         if device_id:
             user = get_object_or_404(User, device_id=device_id)
             serializer = CustomUserSerializer(
@@ -65,7 +67,7 @@ class CreateUpdateUserView(APIView):
                 return Response(serializer.data)
             return Response(serializer.errors,
                             status=status.HTTP_400_BAD_REQUEST)
-        return Response({'error_message': 'Device id не был передан.'},
+        return Response({'error_message': 'Device-Id не был передан.'},
                         status=status.HTTP_400_BAD_REQUEST)
 
 
@@ -104,6 +106,18 @@ class CustomSessionViewSet(viewsets.ModelViewSet):
 
     serializer_class = CustomSessionCreateSerializer
     queryset = CustomSession.objects.all()
+
+    @session_schema['create']
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+    # def get_serializer(self, *args, **kwargs):
+    #     kwargs['context'] = self.get_serializer_context()
+    #     return super().get_serializer(*args, **kwargs)
+
+    # def get_serializer_context(self):
+    #     context = super().get_serializer_context()
+    #     context['request'] = self.request
+    #     return context
 
     @match_list_schema['get']
     @action(detail=True, methods=['get'])

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -154,6 +154,13 @@ SPECTACULAR_SETTINGS = {
         "filter": True,
     },
     "COMPONENT_SPLIT_REQUEST": True,
+    'SECURITY_DEFINITIONS': {
+        'Device-Id Header': {
+            'type': 'apiKey',
+            'name': 'Device-Id',
+            'in': 'header',
+        },
+    },
 }
 
 LOGGING = {

--- a/backend/services/kinopoisk/kinopoisk_service.py
+++ b/backend/services/kinopoisk/kinopoisk_service.py
@@ -65,7 +65,7 @@ class KinopoiskMovies(KinopoiskService):
 
         search_by = 'lists'
         pattern = self.collections
-        movie, cartoon, anime = 'movie', 'cartoon', 'anime'
+        movie, cartoon, anime = ['movie', 'cartoon', 'anime']
         if self.genres:
             search_by = 'genres.name'
             pattern = list(map(lambda s: s.lower(), self.genres))
@@ -76,11 +76,11 @@ class KinopoiskMovies(KinopoiskService):
         if pattern:
             params = {
                 search_by: pattern,
-                'selectFields': ('id', 'name'),
+                'selectFields': ('id', 'name', 'genres', 'type'),
                 'page': page,
                 'limit': limit,
-                'notNullFields': ('id', 'name'),
-                'type': [movie, cartoon, anime],
+                'notNullFields': ('id', 'name', 'genres.name', 'type'),
+                'type': [movie, cartoon, anime, '!animated-series', '!tv-series'],
             }
             if sort_by_rating:
                 params['sortField'] = 'rating.kp'

--- a/backend/services/kinopoisk/kinopoisk_service.py
+++ b/backend/services/kinopoisk/kinopoisk_service.py
@@ -76,11 +76,13 @@ class KinopoiskMovies(KinopoiskService):
         if pattern:
             params = {
                 search_by: pattern,
-                'selectFields': ('id', 'name', 'genres', 'type'),
+                'selectFields': ('id', 'name'),
                 'page': page,
                 'limit': limit,
-                'notNullFields': ('id', 'name', 'genres.name', 'type'),
-                'type': [movie, cartoon, anime, '!animated-series', '!tv-series'],
+                'notNullFields': ('id', 'name'),
+                'type': [
+                    movie, cartoon, anime, '!animated-series', '!tv-series'
+                ],
             }
             if sort_by_rating:
                 params['sortField'] = 'rating.kp'

--- a/backend/services/schemas.py
+++ b/backend/services/schemas.py
@@ -1,21 +1,26 @@
-from api.serializers import (CustomUserSerializer, MovieDetailSerializer,
+from api.serializers import (CustomUserSerializer,
+                             CustomSessionCreateSerializer,
+                             MovieDetailSerializer,
                              MovieSerializer)
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
+
+
+device_id_header = OpenApiParameter(
+    name='Device-Id',
+    type=str,
+    location=OpenApiParameter.HEADER,
+    required=True,
+    description='Device-Id пользователя'
+)
+
 
 user_schema = {
     'get': extend_schema(
         summary='Получение данных пользователя',
         description='Возвращает данные пользователя по указанному device_id',
         methods=['GET'],
-        parameters=[
-            OpenApiParameter(
-                name='device_id',
-                type=str,
-                location=OpenApiParameter.QUERY,
-                required=True,
-            )
-        ],
+        parameters=[device_id_header],
         responses={
             200: CustomUserSerializer,
             400: OpenApiResponse(description='Bad Request'),
@@ -25,6 +30,7 @@ user_schema = {
         summary='Создание пользователя',
         description='Создает нового пользователя',
         methods=['POST'],
+        parameters=[device_id_header],
         request=CustomUserSerializer,
         responses={
             201: CustomUserSerializer,
@@ -35,14 +41,7 @@ user_schema = {
         summary='Обновление данных пользователя',
         description='Обновляет данные существующего пользователя по device_id',
         methods=['PUT'],
-        parameters=[
-            OpenApiParameter(
-                name='device_id',
-                type=str,
-                location=OpenApiParameter.QUERY,
-                required=True,
-            )
-        ],
+        parameters=[device_id_header],
         request=CustomUserSerializer,
         responses={
             200: CustomUserSerializer,
@@ -83,4 +82,28 @@ movie_detail_schema = {
                 description='Фильм отсутствует в базе данных'),
         }
     )
+}
+
+session_schema = {
+    'get': extend_schema(
+        summary='Получение данных сессии текущего пользователя',
+        description='Возвращает данные сессии',
+        methods=['GET'],
+        parameters=[device_id_header],
+        responses={
+            200: CustomSessionCreateSerializer,
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    ),
+    'create': extend_schema(
+        summary='Создание сессии',
+        description='Создает новую сессию',
+        methods=['POST'],
+        parameters=[device_id_header],
+        request=CustomSessionCreateSerializer,
+        responses={
+            201: CustomSessionCreateSerializer,
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    ),
 }

--- a/backend/services/schemas.py
+++ b/backend/services/schemas.py
@@ -1,10 +1,8 @@
-from api.serializers import (CustomUserSerializer,
-                             CustomSessionCreateSerializer,
-                             MovieDetailSerializer,
+from api.serializers import (CustomSessionCreateSerializer,
+                             CustomUserSerializer, MovieDetailSerializer,
                              MovieSerializer)
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
-
 
 device_id_header = OpenApiParameter(
     name='Device-Id',

--- a/backend/services/schemas.py
+++ b/backend/services/schemas.py
@@ -1,5 +1,7 @@
-from api.serializers import (CustomSessionCreateSerializer,
-                             CustomUserSerializer, MovieDetailSerializer,
+from api.serializers import (CollectionSerializer,
+                             CustomSessionCreateSerializer,
+                             CustomUserSerializer, GenreSerializer,
+                             MovieDetailSerializer, MovieRouletteSerializer,
                              MovieSerializer)
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
@@ -104,4 +106,46 @@ session_schema = {
             400: OpenApiResponse(description='Bad Request'),
         }
     ),
+}
+
+genres_schema = {
+    'get': extend_schema(
+        summary='Получение списка жанров',
+        description=(
+            'Возвращает список всех жанров'
+        ),
+        methods=['GET'],
+        responses={
+            200: GenreSerializer(many=True),
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    )
+}
+
+collections_schema = {
+    'get': extend_schema(
+        summary='Получение списка подборок',
+        description=(
+            'Возвращает список всех подборок с Кинопоиска'
+        ),
+        methods=['GET'],
+        responses={
+            200: CollectionSerializer(many=True),
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    )
+}
+
+roulette_schema = {
+    'get': extend_schema(
+        summary='Рулетка',
+        description=(
+            'Возвращает случайный фильм из мэтчей'
+        ),
+        methods=['GET'],
+        responses={
+            200: MovieRouletteSerializer(many=True),
+            400: OpenApiResponse(description='Bad Request'),
+        }
+    )
 }


### PR DESCRIPTION
- добавила возможность получения Device-Id из заголовка запроса. Как заголовок оно должно быть написано именно так, с нижним подчеркиванием не работало. 
В сериализаторе юзера удалила write_only=True для device_id - тк в модели для этого поля установлено primary_key=True - это вызывало ошибку

- работает добавление юзеров при создании сессии

- дополнила документацию для сваггера к запросам на создание Пользователя и Сессии

- изменила эндпойнты получения списков и деталей фильмов, чтобы выдавались только фильмы из конкретной сессии

**UPD 26.06**
- отредактировала эндпойнты получения списков и деталей фильмов, объединив в MovieViewSet
- добавила сериализатор сокращенного представления фильма для Рулетки
- добавила эндпойнт документации Redoc
- отредактировала kinopoisk-service, чтобы в выдачу не попадали сериалы и мультсериал