### PR TITLE
DP53:add voting and matches broadcasting

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,15 +1,30 @@
 import logging
 
 import requests.exceptions
-from custom_sessions.models import CustomSession
+from custom_sessions.models import CustomSession, CustomSessionMovieVote
 from movies.models import Collection, Genre, Movie
 from rest_framework import serializers
+from rest_framework.validators import UniqueTogetherValidator
 from services.kinopoisk.kinopoisk_service import (KinopoiskMovieInfo,
                                                   KinopoiskMovies)
 from services.validators import validate_name
 from users.models import User
 
 logger = logging.getLogger("serializers")
+
+
+class CreateVoteSerializer(serializers.ModelSerializer):
+    """Serializer to add votes."""
+    class Meta:
+        model = CustomSessionMovieVote
+        fields = "__all__"
+        validators = [
+            UniqueTogetherValidator(
+                queryset=CustomSessionMovieVote.objects.all(),
+                fields=["session_id", "user_id", "movie_id"],
+                message="Вы уже проголосовали за этот фильм"
+            )
+        ]
 
 
 class CustomUserSerializer(serializers.ModelSerializer):

--- a/backend/custom_sessions/models.py
+++ b/backend/custom_sessions/models.py
@@ -62,3 +62,32 @@ class CustomSession(models.Model):
             return format_date(self.date)
         else:
             return 'Дата не установлена'
+
+
+class CustomSessionMovieVote(models.Model):
+    """Model for movie votes within session."""
+    session_id = models.ForeignKey(
+        CustomSession,
+        related_name="votes",
+        on_delete=models.CASCADE,
+    )
+    user_id = models.ForeignKey(
+        User,
+        related_name="votes",
+        on_delete=models.CASCADE
+    )
+    movie_id = models.ForeignKey(
+        Movie,
+        related_name="votes",
+        on_delete=models.CASCADE
+    )
+
+    class Meta:
+        verbose_name = "CustomSessionMovieVote"
+        verbose_name_plural = "CustomSessionMovieVotes"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["session_id", "user_id", "movie_id"],
+                name='unique_vote'
+            )
+        ]


### PR DESCRIPTION
Что сделал:
- добавил голосование
- настроил добавление совпадений в сессию + отправку сообщений на вебсокет

Не тестил.

Где сомневаюсь:
- как отработает values_list - в документации (https://docs.djangoproject.com/en/5.0/ref/models/querysets/) написано что он возвращает queryset, может нужно дополнительно в list обернуть, плюс почему то VScode подсвечивает проверку in и not in с вот таким меседжем "(function) def __contains__(x: object) -> bool," попытал chatGPT по этому поводу он вроде говорит что не надо использовать contains, т.к. это только для PostgreSQL with arrays - вроде как наш случай но хз
- как добавятся url в этом случае, т.е. будет ли like вот здесь -> sessions/(?P<session_id>[^/.]+)/movies/<movie_id>/like
- можно сделать метод post без сериализатора, но с сериализатором вроде как меньше проверок нужно прописывать, поэтому решил сделать так