### PR TITLE
DP68: add AsyncWebsocketConsumer RabbitMQ to channels

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -1,42 +1,43 @@
 # api/consumers.py
 import json
 
-from asgiref.sync import async_to_sync
-from channels.generic.websocket import WebsocketConsumer
+from channels.generic.websocket import AsyncWebsocketConsumer
 
 
-class CustomSessionConsumer(WebsocketConsumer):
-    def connect(self):
-        self.room_name = self.scope["url_route"]["kwargs"]["session_id"]
+class ChatConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.room_name = self.scope["url_route"]["kwargs"]["room_name"]
         self.endpoint = self.scope["url_route"]["kwargs"]["endpoint"]
-        self.room_group_name = f"chat_{self.room_name}_{self.endpoint}"
+        self.room_group_name = f"chat_{self.room_name}"
 
         # Join room group
-        async_to_sync(self.channel_layer.group_add)(
-            self.room_group_name, self.channel_name
+        await self.channel_layer.group_add(
+            self.room_group_name,
+            self.channel_name
         )
 
-        self.accept()
+        await self.accept()
 
-    def disconnect(self, close_code):
+    async def disconnect(self, close_code):
         # Leave room group
-        async_to_sync(self.channel_layer.group_discard)(
-            self.room_group_name, self.channel_name
+        await self.channel_layer.group_discard(
+            self.room_group_name,
+            self.channel_name
         )
 
     # Receive message from WebSocket
-    def receive(self, text_data):
+    async def receive(self, text_data):
         text_data_json = json.loads(text_data)
         message = text_data_json["message"]
 
         # Send message to room group
-        async_to_sync(self.channel_layer.group_send)(
-            self.room_group_name, {"type": "chat_message", "message": message}
+        await self.channel_layer.group_send(
+            self.room_group_name, {"type": "chat.message", "message": message}
         )
 
     # Receive message from room group
-    def chat_message(self, event):
+    async def chat_message(self, event):
         message = event["message"]
 
         # Send message to WebSocket
-        self.send(text_data=json.dumps({"message": message}))
+        await self.send(text_data=json.dumps({"message": message}))

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -75,14 +75,14 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "backend.wsgi.application"
 # Channels
-REDIS_HOST = os.getenv("REDIS_HOST", default="127.0.0.1")
-REDIS_PORT = os.getenv("REDIS_PORT", default="6379")
+RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", default="amqp://guest:guest@127.0.0.1/asgi")
+
 ASGI_APPLICATION = "backend.asgi.application"
 CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "BACKEND": "channels_rabbitmq.core.RabbitmqChannelLayer",
         "CONFIG": {
-            "hosts": [(REDIS_HOST, int(REDIS_PORT))],
+            "host": RABBITMQ_HOST,
         },
     },
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,9 +3,11 @@ attrs==23.2.0
 autobahn==23.6.2
 Automat==22.10.0
 Babel==2.15.0
+carehare==1.0.2
 certifi==2024.6.2
 cffi==1.16.0
 channels==4.1.0
+channels-rabbitmq==4.0.1
 channels-redis==4.2.0
 charset-normalizer==3.3.2
 constantly==23.10.4
@@ -26,6 +28,7 @@ jsonschema-specifications==2023.12.1
 mccabe==0.7.0
 msgpack==1.0.8
 packaging==24.0
+pamqp==3.3.0
 pillow==10.3.0
 psycopg2-binary==2.9.9
 pyasn1==0.6.0


### PR DESCRIPTION
Что сделал:
- переписал cunsumer для асинхронной работы
- для channels заменил Redis на RabbitMQ

Сомнения:
1. для send_websocket_message:
- думал что нужно будет переписывать, из-за вот этой части в документации 
_"Does not support [Worker and Background Tasks](https://channels.readthedocs.io/en/stable/topics/worker.html). (See [Rationale](https://github.com/CJWorkbench/channels_rabbitmq/pull/11#issuecomment-499185070) and use await get_channel_layer().current_connection to send to job queues.)"_
но вроде это не наш случай, т.к. идет прямая отправка сообщений без использования Background Tasks и то что написано в Accessing Carehare & Publish messages from Celery нам здесь не нужно

2. в settings:
- для CHANNEL_LAYERS в документации host в единственном числе, ни как для Redis, надеюсь эта не ошибка, т.к. вроде порт у них дефолтный и меняется в ssl_context