### PR TITLE
Feat/movie id endpoint

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -1,5 +1,4 @@
 import logging
-
 from datetime import date
 from typing import Any, Optional
 

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,18 +4,26 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
 from rest_framework.routers import DefaultRouter
 
 from .views import (CollectionListView, CreateUpdateUserView,
-                    CustomSessionViewSet, GenreListView, MovieViewSet)
+                    CustomSessionViewSet, GenreListView,
+                    MovieDetailView, MovieViewSet)
 
 router = DefaultRouter()
 router.register(r"sessions", CustomSessionViewSet, basename="sessions")
 router.register(
     r"sessions/(?P<session_id>[^/.]+)/movies", MovieViewSet, basename="movie"
 )
+# router.register(
+#     r"sessions/(?P<session_id>[^/.]+)/movies", MovieViewSet, basename="movie"
+# )
 
 urlpatterns = [
     path("", include(router.urls)),
     path("users/", CreateUpdateUserView.as_view(), name="create_update_user"),
     path("genres/", GenreListView.as_view(), name="genre_list"),
+    path(
+        "movies/<int:movie_id>/",
+        MovieDetailView.as_view(), name="movie_detail"
+    ),
     path("collections/",
          CollectionListView.as_view(),
          name="collections_list"),

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,8 +4,8 @@ from drf_spectacular.views import (SpectacularAPIView, SpectacularRedocView,
 from rest_framework.routers import DefaultRouter
 
 from .views import (CollectionListView, CreateUpdateUserView,
-                    CustomSessionViewSet, GenreListView,
-                    MovieDetailView, MovieViewSet)
+                    CustomSessionViewSet, GenreListView, MovieDetailView,
+                    MovieViewSet)
 
 router = DefaultRouter()
 router.register(r"sessions", CustomSessionViewSet, basename="sessions")

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -3,13 +3,14 @@ from typing import Any, Dict, Optional
 
 from custom_sessions.models import CustomSession, CustomSessionMovieVote
 from django.shortcuts import get_object_or_404
+from movies.models import Movie
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
+from rest_framework.mixins import ListModelMixin
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import GenericViewSet
-from rest_framework.mixins import ListModelMixin
 from services.kinopoisk.kinopoisk_service import (KinopoiskCollections,
                                                   KinopoiskGenres)
 from services.schemas import (collections_schema, genres_schema,
@@ -22,7 +23,6 @@ from .serializers import (CollectionSerializer, CreateVoteSerializer,
                           CustomSessionCreateSerializer, CustomUserSerializer,
                           GenreSerializer, MovieReadDetailSerializer,
                           MovieSerializer)
-from movies.models import Movie
 
 
 class CreateUpdateUserView(APIView):

--- a/backend/movies/models.py
+++ b/backend/movies/models.py
@@ -130,7 +130,7 @@ class Movie(models.Model):
 
     class Meta:
         default_related_name = 'movies'
-        ordering = ("name",)
+        ordering = ("-rating_kp",)
         verbose_name = "Фильм"
         verbose_name_plural = "Фильмы"
 

--- a/backend/services/schemas.py
+++ b/backend/services/schemas.py
@@ -1,7 +1,8 @@
 from api.serializers import (CollectionSerializer,
                              CustomSessionCreateSerializer,
                              CustomUserSerializer, GenreSerializer,
-                             MovieDetailSerializer, MovieRouletteSerializer,
+                             MovieReadDetailSerializer,
+                             MovieRouletteSerializer,
                              MovieSerializer)
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
@@ -144,12 +145,12 @@ movie_schema = {
         description=("Возвращает детали конкретного фильма"),
         methods=["GET"],
         responses={
-            200: MovieDetailSerializer(many=True),
+            200: MovieReadDetailSerializer(many=True),
             400: OpenApiResponse(description="Bad Request"),
         },
         parameters=[
             OpenApiParameter(
-                name="id",
+                name="movie_id",
                 type=int,
                 location=OpenApiParameter.PATH,
                 description="ID фильма",

--- a/backend/services/schemas.py
+++ b/backend/services/schemas.py
@@ -2,8 +2,7 @@ from api.serializers import (CollectionSerializer,
                              CustomSessionCreateSerializer,
                              CustomUserSerializer, GenreSerializer,
                              MovieReadDetailSerializer,
-                             MovieRouletteSerializer,
-                             MovieSerializer)
+                             MovieRouletteSerializer, MovieSerializer)
 from drf_spectacular.utils import (OpenApiParameter, OpenApiResponse,
                                    extend_schema)
 

--- a/backend/services/utils.py
+++ b/backend/services/utils.py
@@ -19,15 +19,14 @@ def send_websocket_message(session_id, endpoint, message):
 
 
 def get_session_image(session):
-    if session.status == 'closed':
-        matched_movies = list(session.matched_movies)
-        if matched_movies:
-            top_movie = max(
-                matched_movies, key=lambda movie: movie.rating_kp
-            )
-            if top_movie and top_movie.poster:
-                session.image = top_movie.poster
-                session.save()
+    matched_movies = list(session.matched_movies)
+    if matched_movies:
+        top_movie = max(
+            matched_movies, key=lambda movie: movie.rating_kp
+        )
+        if top_movie and top_movie.poster:
+            session.image = top_movie.poster
+            session.save()
 
 
 def close_session(session, session_id, send_status=True) -> None:


### PR DESCRIPTION
- создан отдельный эндпойнт для получения полной инфо о фильме  ( http://127.0.0.1:8000/api/movies/<movie_id>/ )
- исправлен вьюсет MovieViewSet, теперь в нем недоступны методы редактирования и удаления фильма, используется для получения набора фильмов внутри сессии и для голосования
- в списке фильмов в сессии отображаются только их id 
- изменен сериалиализатор создания сессии - теперь в теле запроса не требуется передавать ничего кроме жанров или коллекций - дата и статус добавляются автоматически
- изменена сортировка списка фильмов в сессии - по рейтингу кинопоиска, по убыванию
