### PR TITLE
DP72: fix consumers to syn add channels redis

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -16,33 +16,33 @@ class CustomSessionConsumer(WebsocketConsumer):
         self.room_group_name = f"chat_{self.room_name}"
 
         # Join room group
-        await self.channel_layer.group_add(
+        async_to_sync(self.channel_layer.group_add)(
             self.room_group_name,
             self.channel_name
         )
 
-        await self.accept()
+        self.accept()
 
-    async def disconnect(self, close_code):
+    def disconnect(self, close_code):
         # Leave room group
-        await self.channel_layer.group_discard(
+        async_to_sync(self.channel_layer.group_discard)(
             self.room_group_name,
             self.channel_name
         )
 
     # Receive message from WebSocket
-    async def receive(self, text_data):
+    def receive(self, text_data):
         text_data_json = json.loads(text_data)
         message = text_data_json["message"]
 
         # Send message to room group
-        await self.channel_layer.group_send(
+        async_to_sync(self.channel_layer.group_send)(
             self.room_group_name, {"type": "chat.message", "message": message}
         )
 
     # Receive message from room group
-    async def chat_message(self, event):
+    def chat_message(self, event):
         message = event["message"]
 
         # Send message to WebSocket
-        await self.send(text_data=json.dumps({"message": message}))
+        self.send(text_data=json.dumps({"message": message}))

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -75,14 +75,16 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "backend.wsgi.application"
 # Channels
-RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", default="amqp://guest:guest@127.0.0.1/asgi")
+REDIS_HOST = os.getenv("REDIS_HOST", default="127.0.0.1")
+REDIS_PORT = os.getenv("REDIS_PORT", default=6379)
+
 
 ASGI_APPLICATION = "backend.asgi.application"
 CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "channels_rabbitmq.core.RabbitmqChannelLayer",
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "host": RABBITMQ_HOST,
+            "hosts": [(REDIS_HOST, int(REDIS_PORT))],
         },
     },
 }


### PR DESCRIPTION
криво смерджил предыдущую ветку, в результате в develop-patch-1 остались части асинхронного кода и rabbitmq