### PR TITLE
feat/DP78_save_genres_collections_to_DB, add django q task and settings

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -57,10 +57,9 @@ class CollectionSerializer(serializers.ModelSerializer):
         fields = ["name", "slug", "cover"]
 
     def get_cover(self, obj: Collection) -> str | None:
-        if "cover" in obj and "url" in obj["cover"]:
-            return obj["cover"]["url"]
-        else:
-            return None
+        if obj.cover:
+            return obj.cover.url
+        return None
 
 
 class GenreSerializer(serializers.ModelSerializer):
@@ -234,6 +233,7 @@ class MovieReadDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = Movie
         fields = [
+            "id",
             "name",
             "description",
             "year",

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -31,7 +31,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    "django_q",
+    # "django_q",
     "drf_spectacular",
     "rest_framework",
     "debug_toolbar",
@@ -212,12 +212,12 @@ LOGGING = {
     },
 }
 
-Q_CLUSTER = {
-    'name': 'DP_DjangoQ',
-    'workers': 4,
-    'recycle': 500,
-    'timeout': 180,
-    'queue_limit': 50,
-    'bulk': 10,
-    'orm': 'default',  # Использует базу данных Django по умолчанию
-}
+# Q_CLUSTER = {
+#     'name': 'DP_DjangoQ',
+#     'workers': 4,
+#     'recycle': 500,
+#     'timeout': 180,
+#     'queue_limit': 50,
+#     'bulk': 10,
+#     'orm': 'default',  # Использует базу данных Django по умолчанию
+# }

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django_q",
     "drf_spectacular",
     "rest_framework",
     "debug_toolbar",
@@ -209,4 +210,14 @@ LOGGING = {
             'propagate': True,
         },
     },
+}
+
+Q_CLUSTER = {
+    'name': 'DP_DjangoQ',
+    'workers': 4,
+    'recycle': 500,
+    'timeout': 180,
+    'queue_limit': 50,
+    'bulk': 10,
+    'orm': 'default',  # Использует базу данных Django по умолчанию
 }

--- a/backend/services/constants.py
+++ b/backend/services/constants.py
@@ -14,4 +14,4 @@ STATUS_CHOICES = [
     ("closed", "Закрыто"),
 ]
 
-MAX_MOVIES_QUANTITY = 2500
+MAX_MOVIES_QUANTITY = 500

--- a/backend/services/kinopoisk/kinopoisk_service.py
+++ b/backend/services/kinopoisk/kinopoisk_service.py
@@ -180,7 +180,10 @@ class KinopoiskMovieInfo(KinopoiskService):
             movie["directors"] = []
             actor_count = 0
             director_count = 0
-            for person in movie["persons"]:
+            # Используем get с пустым списком по умолчанию
+            persons = movie.get("persons", [])
+
+            for person in persons:
                 if person["enProfession"] == "actor" and actor_count < 4:
                     movie["actors"].append(person["name"])
                     actor_count += 1
@@ -188,7 +191,9 @@ class KinopoiskMovieInfo(KinopoiskService):
                       and director_count < 4):
                     movie["directors"].append(person["name"])
                     director_count += 1
-            del movie["persons"]
+            # Удаляем ключ только если он существует
+            if "persons" in movie:
+                del movie["persons"]
 
     def get_movie(self, movie_id: int):
         """

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -12,3 +12,11 @@ autostart=true
 autorestart=true
 stdout_logfile=/app/logs/asgi.log
 stderr_logfile=/app/logs/asgi_error.log  ; Separate error logs
+
+[program:django-q]
+command=python manage.py qcluster
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/app/logs/django-q.log
+stderr_logfile=/app/logs/django-q.err.log

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -13,10 +13,10 @@ autorestart=true
 stdout_logfile=/app/logs/asgi.log
 stderr_logfile=/app/logs/asgi_error.log  ; Separate error logs
 
-[program:django-q]
-command=python manage.py qcluster
-directory=/app
-autostart=true
-autorestart=true
-stdout_logfile=/app/logs/django-q.log
-stderr_logfile=/app/logs/django-q.err.log
+# [program:django-q]
+# command=python manage.py qcluster
+# directory=/app
+# autostart=true
+# autorestart=true
+# stdout_logfile=/app/logs/django-q.log
+# stderr_logfile=/app/logs/django-q.err.log

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,0 +1,35 @@
+from django.utils import timezone
+from django_q.models import Schedule
+from django_q.tasks import schedule
+from movies.models import Collection, Genre
+from services.kinopoisk.kinopoisk_service import (KinopoiskCollections,
+                                                  KinopoiskGenres)
+
+
+def update_genres_and_collections():
+    kinopoisk_service_genres = KinopoiskGenres()
+    genres_data = kinopoisk_service_genres.get_genres()
+    if genres_data:
+        for genre_data in genres_data:
+            Genre.objects.update_or_create(name=genre_data['name'])
+
+    kinopoisk_service_collections = KinopoiskCollections()
+    collections_data = kinopoisk_service_collections.get_collections()
+    if collections_data:
+        for collection_data in collections_data['docs']:
+            Collection.objects.update_or_create(
+                slug=collection_data['slug'],
+                defaults={
+                    'name': collection_data['name'],
+                    'cover': collection_data.get('cover')
+                }
+            )
+
+
+# Задача должна выполняться каждые 2 недели
+schedule(
+    'backend.tasks.update_genres_and_collections',
+    schedule_type=Schedule.WEEKLY,
+    repeats=-1,
+    next_run=timezone.now() + timezone.timedelta(weeks=2)
+)

--- a/backend/tasks.py
+++ b/backend/tasks.py
@@ -1,35 +1,35 @@
-from django.utils import timezone
-from django_q.models import Schedule
-from django_q.tasks import schedule
-from movies.models import Collection, Genre
-from services.kinopoisk.kinopoisk_service import (KinopoiskCollections,
-                                                  KinopoiskGenres)
+# from django.utils import timezone
+# from django_q.models import Schedule
+# from django_q.tasks import schedule
+# from movies.models import Collection, Genre
+# from services.kinopoisk.kinopoisk_service import (KinopoiskCollections,
+#                                                   KinopoiskGenres)
 
 
-def update_genres_and_collections():
-    kinopoisk_service_genres = KinopoiskGenres()
-    genres_data = kinopoisk_service_genres.get_genres()
-    if genres_data:
-        for genre_data in genres_data:
-            Genre.objects.update_or_create(name=genre_data['name'])
+# def update_genres_and_collections():
+#     kinopoisk_service_genres = KinopoiskGenres()
+#     genres_data = kinopoisk_service_genres.get_genres()
+#     if genres_data:
+#         for genre_data in genres_data:
+#             Genre.objects.update_or_create(name=genre_data['name'])
 
-    kinopoisk_service_collections = KinopoiskCollections()
-    collections_data = kinopoisk_service_collections.get_collections()
-    if collections_data:
-        for collection_data in collections_data['docs']:
-            Collection.objects.update_or_create(
-                slug=collection_data['slug'],
-                defaults={
-                    'name': collection_data['name'],
-                    'cover': collection_data.get('cover')
-                }
-            )
+#     kinopoisk_service_collections = KinopoiskCollections()
+#     collections_data = kinopoisk_service_collections.get_collections()
+#     if collections_data:
+#         for collection_data in collections_data['docs']:
+#             Collection.objects.update_or_create(
+#                 slug=collection_data['slug'],
+#                 defaults={
+#                     'name': collection_data['name'],
+#                     'cover': collection_data.get('cover')
+#                 }
+#             )
 
 
-# Задача должна выполняться каждые 2 недели
-schedule(
-    'backend.tasks.update_genres_and_collections',
-    schedule_type=Schedule.WEEKLY,
-    repeats=-1,
-    next_run=timezone.now() + timezone.timedelta(weeks=2)
-)
+# # Задача должна выполняться каждые 2 недели
+# schedule(
+#     'backend.tasks.update_genres_and_collections',
+#     schedule_type=Schedule.WEEKLY,
+#     repeats=-1,
+#     next_run=timezone.now() + timezone.timedelta(weeks=2)
+# )


### PR DESCRIPTION
- настроила сохранение в БД с кинопоиска списков жанров и коллекций и получение из БД.
-  настроила обновление получения жанров и коллекций раз в 2 недели (Django Q)

второй коммит:
- уменьшила кол-во фильмов в выдаче до 500
- исправила ошибку получения данных фильма с кинопоиска, если в данных нет ключа persons
- добавила id фильма в сериализатор подробностей о фильме
- временно закомментировала настройки Django Q, так как из-за него вылетали ошибки